### PR TITLE
[HDX-6899] stop using prefix env var.

### DIFF
--- a/docker/app.conf.tpl
+++ b/docker/app.conf.tpl
@@ -23,7 +23,7 @@ GIS_API_PATTERN = 'http://gisapi/services/tables/{table_name}'
 # gispreviewbot's key
 CKAN_API_KEY = '${HDX_GIS_API_KEY}'
 # point to our ckan
-CKAN_SERVER_URL = '${HDX_PREFIX}data.${HDX_DOMAIN}'
+CKAN_SERVER_URL = '${HDX_DOMAIN}'
 
 # CKAN_API_BASE_URL = 'http://${HDX_PREFIX}data.${HDX_DOMAIN}/api/action'
 CKAN_API_BASE_URL = 'http://ckan:5000/api/action'


### PR DESCRIPTION
Do not merge until the AWS migration is completed.

During AWS migration (and due to new URL format) we will drop HDX_PREFIX.
