### PR TITLE
to prod! (#33)

### DIFF
--- a/docker/app.conf.tpl
+++ b/docker/app.conf.tpl
@@ -28,6 +28,7 @@ CKAN_API_BASE_URL = 'http://ckan:5000/api/action'
 
 CHECKS_CONFIG_PATH = '/srv/gislayer/config/config.json'
 
+MONITOR_URL = '${MONITOR_URL}'
 HDX_USER_AGENT = '${HDX_USER_AGENT}'
 
 DB_HOST = '${DB_HOST}'

--- a/docker/gisworker/run_gisworker
+++ b/docker/gisworker/run_gisworker
@@ -1,16 +1,22 @@
 #!/usr/bin/with-contenv sh
 
-[ -z ${HDX_REDIS_WORKER_TTL} ] && HDX_REDIS_WORKER_TTL=600
-[ -z ${HDX_REDIS_ADDR} ]       && HDX_REDIS_ADDR=gisredis
-[ -z ${HDX_REDIS_PORT} ]       && HDX_REDIS_PORT=6379
-[ -z ${HDX_REDIS_GISDB} ]      && HDX_REDIS_GISDB=1
+[ -z "${HDX_REDIS_WORKER_TTL}" ] && HDX_REDIS_WORKER_TTL=600
+[ -z "${HDX_REDIS_ADDR}" ]       && HDX_REDIS_ADDR=gisredis
+[ -z "${HDX_REDIS_PORT}" ]       && HDX_REDIS_PORT=6379
+[ -z "${HDX_REDIS_GISDB}" ]      && HDX_REDIS_GISDB=1
+[ -z "${QUEUES}" ]               && QUEUES="geo_q analytics_q"
 
 WORKER_ID=$(ifconfig eth0 | grep inet | awk '{ print $2 }' | awk -F \: '{ print $2 }')
 
+# regenerate app.conf
+envsubst < /srv/gislayer/docker/app.conf.tpl > /srv/app.conf
+
 cd /srv/gislayer
+
+export GIS_REST_LAYER_CONF=/srv/app.conf
 
 exec ./hdxrq.py worker \
     --url redis://${HDX_REDIS_ADDR}:${HDX_REDIS_PORT}/${HDX_REDIS_GISDB} \
     --name worker-${WORKER_ID} \
     --worker-ttl ${HDX_REDIS_WORKER_TTL} \
-    geo_q analytics_q
+    ${QUEUES}

--- a/docker/run_gislayer
+++ b/docker/run_gislayer
@@ -6,6 +6,8 @@
 [ ! -z "$HDX_GISDB_USER" ] && export DB_USER=$HDX_GISDB_USER
 [ ! -z "$HDX_GISDB_PASS" ] && export DB_PASS=$HDX_GISDB_PASS
 
+[ -z "$MONITOR_URL" ] && MONITOR_URL="/monitor"
+
 # regenerate app.conf
 envsubst < /srv/gislayer/docker/app.conf.tpl > /srv/app.conf
 

--- a/restlayer/__init__.py
+++ b/restlayer/__init__.py
@@ -58,7 +58,7 @@ def create_app():
     scheduler_api.scheduler_api_dict['scheduler'] = scheduler
 
     # rq_dashboard.RQDashboard(app, url_prefix='/monitor')
-    app.register_blueprint(rq_dashboard.blueprint, url_prefix="/monitor")
+    app.register_blueprint(rq_dashboard.blueprint, url_prefix=app.config.get('MONITOR_URL', '/monitor'))
 
     @app.route('/version', methods=['GET'])
     @app.route('/about', methods=['GET'])


### PR DESCRIPTION
* Ops 7732 (#25)

* [OPS-7732] to ECR!

* Ops 7732 (#26)

* [OPS-7732] to ECR!

* hmh

* get the repo name

* no peep needed

* Ops 7732 (#27)

* [OPS-7732] to ECR!

* hmh

* get the repo name

* no peep needed

* fix image name, use v1 on action

* [HDX-7971] bump alpine to 3.14.2; while at it, actually use the python3-base-s6 as base image. (#28)

* add monitor url, hdx queues; generate app.conf for gisworker too.

* fix queues var (#31)

* fix queues var (#32)

[OPS-7732]: https://humanitarian.atlassian.net/browse/OPS-7732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7732]: https://humanitarian.atlassian.net/browse/OPS-7732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPS-7732]: https://humanitarian.atlassian.net/browse/OPS-7732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDX-7971]: https://humanitarian.atlassian.net/browse/HDX-7971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ