### PR TITLE
PR HDX-8773 deal with case when env var doesn't exist

### DIFF
--- a/docker/app.conf.tpl
+++ b/docker/app.conf.tpl
@@ -38,4 +38,4 @@ DB_USER = '${DB_USER}'
 DB_PASS = '${DB_PASS}'
 
 # True if events api should be enabled, otherwise False
-EVENTS_API_ENABLED = ${EVENTS_API_ENABLED}
+EVENTS_API_ENABLED = '${EVENTS_API_ENABLED}'

--- a/eventapi/event_api.py
+++ b/eventapi/event_api.py
@@ -26,7 +26,7 @@ def create_change_events():
         'state': 'success'
     }
     try:
-        if app.config.get('EVENTS_API_ENABLED', False) is True:
+        if app.config.get('EVENTS_API_ENABLED', 'false').lower() == 'true':
             task_arguments = request.get_json()
 
             event_q = event_api_dict.get('event_q')


### PR DESCRIPTION
In that case we should have an empty string. We can't have boolean.